### PR TITLE
Build AWS SDK modules as part of CMake build pipeline

### DIFF
--- a/cmake/TinkWorkspace.cmake
+++ b/cmake/TinkWorkspace.cmake
@@ -93,9 +93,12 @@ http_archive(
   CMAKE_SUBDIR cmake
 )
 
-# Import externally built aws-sdk::core and aws-sdk::kms
-# aws-sdk-cpp-1.8.24 should be located in the same folder as tink.
-set(AWS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../aws-sdk-cpp-1.8.24")
+# Build aws-sdk::core and aws-sdk::kms
+set(AWS_SDK_VERSION 1.8.24)
+set(AWS_MAKE_CMD "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-aws-modules.sh")
+message(STATUS "Downloading and building aws-sdk-cpp-${AWS_SDK_VERSION}")
+execute_process(COMMAND ${AWS_MAKE_CMD} ${CMAKE_BINARY_DIR} ${AWS_SDK_VERSION})
+set(AWS_SRC_DIR "${CMAKE_BINARY_DIR}/aws-sdk-cpp-${AWS_SDK_VERSION}")
 add_library(aws-sdk::core STATIC IMPORTED)
 add_library(aws-sdk::kms  STATIC IMPORTED)
 set_target_properties(aws-sdk::core PROPERTIES IMPORTED_LOCATION ${AWS_SRC_DIR}/build/aws-cpp-sdk-core/libaws-cpp-sdk-core.a)

--- a/cmake/build-aws-modules.sh
+++ b/cmake/build-aws-modules.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# Build static libraries for kms and core modules of aws-cpp-sdk.
+echo "Building aws-sdk"
+CMAKE_BINARY_DIR=$1
+AWS_SDK_VERSION=$2
+cd ${CMAKE_BINARY_DIR}
+wget https://github.com/aws/aws-sdk-cpp/archive/${AWS_SDK_VERSION}.tar.gz
+tar -xvzf ${AWS_SDK_VERSION}.tar.gz
+rm ${AWS_SDK_VERSION}.tar.gz
+cd aws-sdk-cpp-${AWS_SDK_VERSION}
+mkdir build && cd build
+cmake .. \
+    -DBUILD_ONLY=kms \
+    -DSTATIC_LINKING=1 \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DENABLE_TESTING:BOOL=OFF \
+    -DBUILD_DEPS=ON
+make


### PR DESCRIPTION
**Change**

- Add script that externally builds static libraries for required aws-sdk modules
- Call this script from Tink's CMakeLists.txt