### PR TITLE
Use multi-threading when building aws-sdk

### DIFF
--- a/cmake/build-aws-modules.sh
+++ b/cmake/build-aws-modules.sh
@@ -18,4 +18,4 @@ cmake .. \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DENABLE_TESTING:BOOL=OFF \
     -DBUILD_DEPS=ON
-make
+make -j 8


### PR DESCRIPTION
- Use `make -j 8`